### PR TITLE
Make all query types work with granularity #3

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -105,6 +105,9 @@ var GnocchiDatasource = (function () {
                 return self.$q.reject(err);
             }
             resource_type = resource_type || "generic";
+            if (granularity !== '') {
+                default_measures_req.params.granularity = granularity;
+            }
             if (target.queryMode === "resource_search") {
                 var resource_search_req = self.buildQueryRequest(resource_type, resource_search);
                 return self._gnocchi_request(resource_search_req).then(function (result) {
@@ -113,9 +116,6 @@ var GnocchiDatasource = (function () {
                         var metric_names = _.filter(_.keys(resource["metrics"]), function (name) { return re.test(name); });
                         return _.map(metric_names, function (metric_name) {
                             var measures_req = _.merge({}, default_measures_req);
-                            if (granularity !== '') {
-                                measures_req.params.granularity = granularity;
-                            }
                             measures_req.url = ('v1/resource/' + resource_type +
                                 '/' + resource["id"] + '/metric/' + metric_name + '/measures');
                             var final_label = self._compute_label(label, resource);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -127,7 +127,9 @@ export default class GnocchiDatasource {
         }
 
         resource_type = resource_type || "generic";
-
+        if (granularity !== '') {
+            default_measures_req.params.granularity = granularity;
+        }
         if (target.queryMode === "resource_search") {
           var resource_search_req = self.buildQueryRequest(resource_type, resource_search);
           return self._gnocchi_request(resource_search_req).then(function(result) {
@@ -139,9 +141,6 @@ export default class GnocchiDatasource {
 
               return _.map(metric_names, function(metric_name){
                 var measures_req = _.merge({}, default_measures_req);
-                if (granularity !== '') {
-                    measures_req.params.granularity = granularity;
-                }
                 measures_req.url = ('v1/resource/' + resource_type +
                                     '/' + resource["id"] + '/metric/' + metric_name + '/measures');
                 var final_label = self._compute_label(label, resource);

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -42,7 +42,7 @@
             <label class="gf-form-label query-keyword width-8">Label</label>
             <input type="text" class="gf-form-input" ng-model="ctrl.target.label" spellcheck='false' placeholder="$id" data-min-length=0 ng-model-onblur ng-blur="ctrl.queryUpdated()">
         </div>
-        <div class="gf-form max-width-20" ng-if="['resource', 'resource_search', 'resource_aggregation'].indexOf(ctrl.target.queryMode) >= 0" >
+        <div class="gf-form max-width-20">
             <label class="gf-form-label query-keyword width-8">Granularity</label>
             <input type="text" class="gf-form-input" ng-model="ctrl.target.granularity" spellcheck='false' placeholder="seconds" data-min-length=0 ng-model-onblur ng-blur="ctrl.queryUpdated()">
         </div>


### PR DESCRIPTION
The original code only utilize granularity paramater when using resource aggregation query type.
The change make it available to all types.
related issue #3