### PR TITLE
Change project name to id

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -864,7 +864,7 @@ var GnocchiDatasource = /** @class */ (function () {
                     "scope": {
                         "project": {
                             "domain": { "id": this.domain },
-                            "name": this.project,
+                            "id": this.project,
                         }
                     }
                 }


### PR DESCRIPTION
Project name may contain special characters so it's better to use project id when doing authentication